### PR TITLE
WIP/DRAFT: OSD-28241: Allow building backplane connections with provided OCM connection

### DIFF
--- a/pkg/backplaneapi/clientUtils.go
+++ b/pkg/backplaneapi/clientUtils.go
@@ -7,18 +7,19 @@ import (
 	"net/http"
 	"net/url"
 
+	ocmsdk "github.com/openshift-online/ocm-sdk-go"
 	BackplaneApi "github.com/openshift/backplane-api/pkg/client"
-	logger "github.com/sirupsen/logrus"
-
 	"github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/openshift/backplane-cli/pkg/info"
 	"github.com/openshift/backplane-cli/pkg/ocm"
+	logger "github.com/sirupsen/logrus"
 )
 
 type ClientUtils interface {
 	MakeBackplaneAPIClient(base string) (BackplaneApi.ClientWithResponsesInterface, error)
 	MakeBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientWithResponsesInterface, error)
 	MakeRawBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientInterface, error)
+	MakeRawBackplaneAPIClientWithAccessTokenWithConn(base, accessToken string, ocmConn *ocmsdk.Connection) (BackplaneApi.ClientInterface, error)
 	MakeRawBackplaneAPIClient(base string) (BackplaneApi.ClientInterface, error)
 	GetBackplaneClient(backplaneURL string, ocmToken string, proxyURL *string) (client BackplaneApi.ClientInterface, err error)
 	SetClientProxyURL(proxyURL string) error
@@ -45,9 +46,20 @@ func makeClientOptions(accessToken string) BackplaneApi.ClientOption {
 }
 
 func (s *DefaultClientUtilsImpl) MakeRawBackplaneAPIClientWithAccessToken(base, accessToken string) (BackplaneApi.ClientInterface, error) {
+	return s.MakeRawBackplaneAPIClientWithAccessTokenWithConn(base, accessToken, nil)
+}
+
+func (s *DefaultClientUtilsImpl) MakeRawBackplaneAPIClientWithAccessTokenWithConn(base, accessToken string, ocmConn *ocmsdk.Connection) (BackplaneApi.ClientInterface, error) {
+
 	// Inject client Proxy Url from config
 	if s.clientProxyURL == "" {
-		bpConfig, err := config.GetBackplaneConfiguration()
+		var bpConfig config.BackplaneConfiguration
+		var err error = nil
+		if ocmConn != nil {
+			bpConfig, err = config.GetBackplaneConfigurationWithConn(ocmConn)
+		} else {
+			bpConfig, err = config.GetBackplaneConfiguration()
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/backplaneapi/clientUtils.go
+++ b/pkg/backplaneapi/clientUtils.go
@@ -54,7 +54,7 @@ func (s *DefaultClientUtilsImpl) MakeRawBackplaneAPIClientWithAccessTokenWithCon
 	// Inject client Proxy Url from config
 	if s.clientProxyURL == "" {
 		var bpConfig config.BackplaneConfiguration
-		var err error = nil
+		var err error
 		if ocmConn != nil {
 			bpConfig, err = config.GetBackplaneConfigurationWithConn(ocmConn)
 		} else {

--- a/pkg/backplaneapi/mocks/clientUtilsMock.go
+++ b/pkg/backplaneapi/mocks/clientUtilsMock.go
@@ -14,6 +14,7 @@ import (
 
 	Openapi "github.com/openshift/backplane-api/pkg/client"
 	gomock "go.uber.org/mock/gomock"
+	ocmsdk "github.com/openshift-online/ocm-sdk-go"
 )
 
 // MockClientUtils is a mock of ClientUtils interface.
@@ -113,6 +114,21 @@ func (m *MockClientUtils) MakeRawBackplaneAPIClientWithAccessToken(base, accessT
 func (mr *MockClientUtilsMockRecorder) MakeRawBackplaneAPIClientWithAccessToken(base, accessToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRawBackplaneAPIClientWithAccessToken", reflect.TypeOf((*MockClientUtils)(nil).MakeRawBackplaneAPIClientWithAccessToken), base, accessToken)
+}
+
+// MakeRawBackplaneAPIClientWithAccessTokenWithConn mocks base method.
+func (m *MockClientUtils) MakeRawBackplaneAPIClientWithAccessTokenWithConn(arg0, arg1 string, arg2 *ocmsdk.Connection) (Openapi.ClientInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeRawBackplaneAPIClientWithAccessTokenWithConn", arg0, arg1)
+	ret0, _ := ret[0].(Openapi.ClientInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MakeRawBackplaneAPIClientWithAccessTokenWithConn indicates an expected call of MakeRawBackplaneAPIClientWithAccessTokenWithConn.
+func (mr *MockClientUtilsMockRecorder) MakeRawBackplaneAPIClientWithAccessTokenWithConn(arg0, arg1 interface{}, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRawBackplaneAPIClientWithAccessTokenWithConn", reflect.TypeOf((*MockClientUtils)(nil).MakeRawBackplaneAPIClientWithAccessTokenWithConn), arg0, arg1)
 }
 
 // SetClientProxyURL mocks base method.

--- a/pkg/ocm/mocks/ocmWrapperMock.go
+++ b/pkg/ocm/mocks/ocmWrapperMock.go
@@ -179,6 +179,21 @@ func (mr *MockOCMInterfaceMockRecorder) GetOCMEnvironment() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOCMEnvironment", reflect.TypeOf((*MockOCMInterface)(nil).GetOCMEnvironment))
 }
 
+// GetOCMEnvironmentWithConn mocks base method.
+func (m *MockOCMInterface) GetOCMEnvironmentWithConn(arg0 *sdk.Connection) (*v10.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOCMEnvironmentWithConn")
+	ret0, _ := ret[0].(*v10.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOCMEnvironmentWithConn indicates an expected call of GetOCMEnvironmentWithConn.
+func (mr *MockOCMInterfaceMockRecorder) GetOCMEnvironmentWithConn(arg0 *sdk.Connection) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOCMEnvironmentWithConn", reflect.TypeOf((*MockOCMInterface)(nil).GetOCMEnvironment))
+}
+
 // GetPullSecret mocks base method.
 func (m *MockOCMInterface) GetPullSecret() (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -396,7 +396,6 @@ func (o *DefaultOCMInterfaceImpl) GetOCMEnvironment() (*cmv1.Environment, error)
 		return nil, fmt.Errorf("failed to create OCM connection: %v", err)
 	}
 
-	defer connection.Close()
 	return o.GetOCMEnvironmentWithConn(connection)
 }
 


### PR DESCRIPTION
This PR allows an OCM connection to be provided to the config building and login functions. 

Why?

1. Today as part of the client connection setup/code-path,  it is difficult (not possible?) to create a clean separation of OCM config to be provided to multiple OCM clients/connections within a single util. It appears that through a chain of functions, the use of env vars prevents this from working as desired. This attempts to allow utils sharing backplane code to interact with clusters which reside in different OCM envs within the same executable. The most relevant use case is testing/developing within pre-production STAGE and INTEGRATION envs, where Hive uses PROD.  
2. Avoiding rebuilding multiple OCM connections during the config + login phases, this may be more efficient as well as more consistent  (rebuilding/refetching OCM attributes may introduce unlikely race conditions)



